### PR TITLE
Align HTML test cases with expected links that should be found.

### DIFF
--- a/test-cases/html/body/iframe/srcdoc.html
+++ b/test-cases/html/body/iframe/srcdoc.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CrawlMaze - Testbed for Web Crawlers - iframe tag</title>
 <h1> srcdoc attribute </h1>
-<iframe srcdoc="<img src=/test/html/body/iframe/srcdoc.html>"></iframe>
+<iframe srcdoc="<img src=/test/html/body/iframe/srcdoc.found>"></iframe>
 <p>
    The srcdoc attribute specifies the HTML content of the page to show in the inline frame.
 </p>

--- a/test-cases/html/body/map/area/ping.html
+++ b/test-cases/html/body/map/area/ping.html
@@ -4,7 +4,7 @@
 <h1> map ping </h1>
 <img src="data:;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw" width="150" height="150" usemap="#map">
 <map name="map">
-  <area ping="/test/html/body/map/ping.found" shape="rect" coords="0,0,150,150" href="#">
+  <area ping="/test/html/body/map/area/ping.found" shape="rect" coords="0,0,150,150" href="#">
 </map>
 <p>
   The ping attribute contains a space-separated list of URLs to which, when the hyperlink is followed,


### PR DESCRIPTION
Currently, the expected links that should be found according to the `expected-results.json` does not correctly reflect the test cases for iframe srcdoc and map area pings. The naming convention suggests, that the expected values refer to the correct values, therefore, these changes align the links to be found in the test case with the `expected-results.json`.
