### PR TITLE
Fix cite.found link

### DIFF
--- a/test-cases/html/body/blockquote/cite.html
+++ b/test-cases/html/body/blockquote/cite.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CrawlMaze - Testbed for Web Crawlers - blockquote tag</title>
 <h1> cite attribute </h1>
-<blockquote cite="/test/html/body/applet/codebase.found"></blockquote>
+<blockquote cite="/test/html/body/blockquote/cite.found"></blockquote>
 <p>
   In HTML 4.01, the tag defines a long quotation.<br>
   In HTML5, the tag specifies a section that is quoted from another source.


### PR DESCRIPTION
According to https://github.com/google/security-crawl-maze/blob/master/blueprints/utils/resources/expected-results.json#L15 "/html/body/blockquote/cite.found" should be one of the URLs that can be discovered.
However this file defines "/test/html/body/applet/codebase.found" which is also defined in https://github.com/google/security-crawl-maze/blob/master/test-cases/html/body/applet/codebase.html - looks like a copy-and-paste bug?
I think this is what was actually intended.