### PR TITLE
Update node version to 14.x and fix angular build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # The builder image is used to install all the tools required to build one page applications.
 # All the tools are abandoned after the production image is built. It lets us
 # create a very lightweight container with bundled files without any node tools.
-FROM node:10-alpine AS builder
+FROM node:14-alpine AS builder
 
 # Allows npm to run within the context of the running script.
 # Needed to install Angular CLI.


### PR DESCRIPTION
Update node version, to 14.x so angular can be build and avoid this error: 

```
 => [builder  5/16] COPY test-cases/javascript/frameworks/angular /tmp/angular                                                                                                                                                                  0.0s 
 => [builder  6/16] WORKDIR /tmp/angular                                                                                                                                                                                                        0.0s 
 => [builder  7/16] RUN npm install                                                                                                                                                                                                            19.0s 
 => ERROR [builder  8/16] RUN ng build --prod --baseHref=/javascript/frameworks/angular/                                                                                                                                                        0.2s 
------                                                                                                                                                                                                                                               
 > [builder  8/16] RUN ng build --prod --baseHref=/javascript/frameworks/angular/:                                                                                                                                                                   
#24 0.209 Node.js version v10.24.1 detected.                                                                                                                                                                                                         
#24 0.209 The Angular CLI requires a minimum Node.js version of either v12.20, v14.15, or v16.10.                                                                                                                                                    
#24 0.209                                                                                                                                                                                                                                            
#24 0.209 Please update your Node.js version or visit https://nodejs.org/ for additional instructions.
#24 0.209 
------
executor failed running [/bin/sh -c ng build --prod --baseHref=/javascript/frameworks/angular/]: exit code: 3
```