### PR TITLE
fixs of minor url inconsistencies

### DIFF
--- a/test-cases/html/body/img/src-data.html
+++ b/test-cases/html/body/img/src-data.html
@@ -2,7 +2,7 @@
 <meta charset="utf-8">
 <title>CrawlMaze - Testbed for Web Crawlers - img tag</title>
 <h1> src attribute with data:image notation </h1>
-<img src="data:image/svg+xml,<svg%20xmlns='%68ttp:%2f/www.w3.org/2000/svg'%20xmlns:xlink='%68ttp:%2f/www.w3.org/1999/xlink'><image%20xlink:hr%65f='/html/body/img/src-data.found'></image></svg>">
+<img src="data:image/svg+xml,<svg%20xmlns='%68ttp:%2f/www.w3.org/2000/svg'%20xmlns:xlink='%68ttp:%2f/www.w3.org/1999/xlink'><image%20xlink:hr%65f='/test/html/body/img/src-data.found'></image></svg>">
 <p>
     The src attribute specifies the URL of an image.
 </p>


### PR DESCRIPTION
While working on crawlers I noticed some minor inconsistencies that cause some issues with scoring results.
They're pretty self-explanatory, so if you could take a look that would be great. Thanks in advance.