### PR TITLE
fix trailing slashes

### DIFF
--- a/blueprints/html/__init__.py
+++ b/blueprints/html/__init__.py
@@ -47,7 +47,7 @@ def inline_url_string():
 
 
 @html_module.route("/", defaults={"path": ""})
-@html_module.route("/<path:path>")
+@html_module.route("/<path:path>/")
 def html_dir(path):
   """Lists contents of requested directory."""
   requested_path = os.path.join(TEST_CASES_PATH, path)
@@ -56,7 +56,7 @@ def html_dir(path):
 
   if os.path.isdir(requested_path):
     files = os.listdir(requested_path)
-    return render_template("list-html-dir.html", files=files, path=path)
+    return render_template("list-html-dir.html", files=files, path=path if path.endswith("/") else path + "/")
 
   if os.path.isfile(requested_path):
     return send_from_directory("test-cases/html", path)

--- a/blueprints/javascript/__init__.py
+++ b/blueprints/javascript/__init__.py
@@ -83,7 +83,7 @@ def string_concat_variable():
 
 
 @javascript_module.route("/", defaults={"path": ""})
-@javascript_module.route("/<path:path>")
+@javascript_module.route("/<path:path>/")
 def html_dir(path):
   """Lists contents of requested directory."""
   requested_path = os.path.join(TEST_CASES_PATH, path)
@@ -92,7 +92,7 @@ def html_dir(path):
 
   if os.path.isdir(requested_path):
     files = os.listdir(requested_path)
-    return render_template("list-javascript-dir.html", files=files, path=path)
+    return render_template("list-javascript-dir.html", files=files, path=path if path.endswith("/") else path + "/")
 
   if os.path.isfile(requested_path):
     return send_from_directory("test-cases/javascript", path)

--- a/blueprints/misc/__init__.py
+++ b/blueprints/misc/__init__.py
@@ -28,7 +28,7 @@ TEST_CASES_PATH = os.path.abspath(__file__ + "/../../../test-cases/misc/")
 
 
 @misc_module.route("/", defaults={"path": ""})
-@misc_module.route("/<path:path>")
+@misc_module.route("/<path:path>/")
 def html_dir(path):
   """Lists contents of requested directory."""
   requested_path = os.path.join(TEST_CASES_PATH, path)
@@ -37,7 +37,7 @@ def html_dir(path):
 
   if os.path.isdir(requested_path):
     files = os.listdir(requested_path)
-    return render_template("list-misc-dir.html", files=files, path=path)
+    return render_template("list-misc-dir.html", files=files, path=path if path.endswith("/") else path + "/")
 
   if os.path.isfile(requested_path):
     return send_from_directory("test-cases/misc", path)


### PR DESCRIPTION
When accessing nested directory listings without appending a trailing slash, the rendered links are incorrect.

![Screenshot](https://github.com/google/security-crawl-maze/assets/11313340/ebc287d7-d6a9-4686-b3c5-e8ee809007fa)
