### PR TITLE
Fix #17 - pin working version of Angular CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM node:14-alpine AS builder
 RUN npm config set unsafe-perm true
 
 # Install JavaScript framework tools.
-RUN npm install -g @angular/cli
+RUN npm install -g @angular/cli@12.2.0
 RUN npm install -g polymer-cli
 
 # Build Angular app.


### PR DESCRIPTION
Fixes #17 by pinning the Angular CLI to a version that will not cause the build to break